### PR TITLE
Fix crossfade

### DIFF
--- a/radio.liq
+++ b/radio.liq
@@ -166,8 +166,8 @@ radio = switch(id="johnny_switch", [
 def transition(a, b)
     add(
         normalize=false,
-        [fade.in(duration=3., type="log", b),
-         fade.out(duration=3., type="log", a)],
+        [fade.initial(duration=5., b),
+         fade.final(duration=5., a)],
     )
 end
 


### PR DESCRIPTION
It seems like fade.out wasn't fading out the song sufficiently, so use
fade.final instead which fades to silence like we want.