### PR TITLE
Add "transition_with_skip" that skips track

### DIFF
--- a/radio.liq
+++ b/radio.liq
@@ -187,12 +187,18 @@ def transition(a, b)
     )
 end
 
+# Fade the current track out and skip to the next source, skipping a track
+def transition_with_skip(a, b)
+    source.skip(b)
+    sequence([fade.final(duration=5., a), b])
+end
+
 # When a live stream connects or a track is added to the prerecorded queue,
 # immediately switch to it with a crossfade
 radio = fallback(
     id="primary_input_fallback",
     track_sensitive=false,
-    transitions=[transition, transition, transition],
+    transitions=[transition, transition, transition_with_skip],
     [
         remote_live,
         prerecorded,


### PR DESCRIPTION
This is used for the transition to the radio source. This way, when a
prerecorded show ends, the switch statement that determines what to play
will be called again to ensure traffic is played as quickly as possible.
This may also help with ensuring that we aren't playing music outside of
its scheduled hour.