### PR TITLE
Updated Liquidsoap to version 2.3.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,8 @@
-FROM savonet/liquidsoap:v1.4.4
+FROM savonet/liquidsoap:v2.3.3
 
 USER root
 
-RUN sed -i 's/testing/bullseye/g' /etc/apt/sources.list \
-        && apt-get update \
+RUN apt-get update \
         && apt-get -y install python3 python3-requests \
         && rm -rf /var/lib/apt/lists/*
 RUN usermod -aG audio daemon \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,7 @@ FROM savonet/liquidsoap:v2.3.3
 USER root
 
 RUN apt-get update \
-        && apt-get -y install python3 python3-requests \
-        && rm -rf /var/lib/apt/lists/*
+        && apt-get -y install python3 python3-requests
 RUN usermod -aG audio daemon \
         && install -d -m 0755 -o daemon -g daemon /opt/johnny-six \
         && usermod -d /opt/johnny-six daemon

--- a/config.liq.example
+++ b/config.liq.example
@@ -1,14 +1,11 @@
-set("log.file.path", "/tmp/liquidsoap.log")
-set("log.stdout", true)
+settings.log.file.path := "/tmp/liquidsoap.log"
+settings.log.stdout := true
 
-set("server.socket", true)
-set("server.socket.path", "/tmp/liquidsoap.sock")
+settings.server.socket := true
+settings.server.socket.path := "/tmp/liquidsoap.sock"
 
-set("scheduler.fast_queues", 1)
-set("scheduler.generic_queues", 6)
-
-set("harbor.ssl.certificate", "/etc/harbor/cert.pem")
-set("harbor.ssl.private_key", "/etc/harbor/privkey.pem")
+settings.scheduler.fast_queues := 1
+settings.scheduler.generic_queues := 6
 
 script_path = "/opt/johnny-six"
 base_path = "/opt/wuvt/automation"

--- a/config_docker.liq
+++ b/config_docker.liq
@@ -2,7 +2,7 @@ set("harbor.ssl.certificate", "/etc/harbor/cert.pem")
 set("harbor.ssl.private_key", "/etc/harbor/privkey.pem")
 
 script_path = "/usr/src/app"
-base_path = getenv("BASE_PATH")
-trackman_url = getenv("TRACKMAN_URL")
-trackman_password = getenv("TRACKMAN_PASSWORD")
-playlist_api_url = getenv("PLAYLIST_API_URL")
+base_path = environment.get("BASE_PATH")
+trackman_url = environment.get("TRACKMAN_URL")
+trackman_password = environment.get("TRACKMAN_PASSWORD")
+playlist_api_url = environment.get("PLAYLIST_API_URL")

--- a/config_docker.liq
+++ b/config_docker.liq
@@ -1,6 +1,3 @@
-set("harbor.ssl.certificate", "/etc/harbor/cert.pem")
-set("harbor.ssl.private_key", "/etc/harbor/privkey.pem")
-
 script_path = "/usr/src/app"
 base_path = environment.get("BASE_PATH")
 trackman_url = environment.get("TRACKMAN_URL")

--- a/radio.liq
+++ b/radio.liq
@@ -81,7 +81,7 @@ def log_metadata(m) =
     if http_response.status_code == 201 then
         log(label="log_metadata", "Track logged successfully")
     else
-        log(label="log_metadata",  "Failed to log track")
+        log(label="log_metadata",  "Failed to log track #{http_response}")
     end
 end
 

--- a/radio.liq
+++ b/radio.liq
@@ -14,7 +14,7 @@
 #end
 
 def next_track_request() =
-    result = list.hd(default="", get_process_lines(
+    result = list.hd(default="", process.read.lines(
         "curl -fsL #{playlist_api_url}/next_track"))
     if result == "" then
         []
@@ -24,13 +24,13 @@ def next_track_request() =
 end
 
 def next_track_local_request() =
-    result = list.hd(default="", get_process_lines(
+    result = list.hd(default="", process.read.lines(
         "python3 #{script_path}/get_track.py #{base_path}"))
     [request.create(result)]
 end
 
 def prerecorded_request() =
-    result = list.hd(default="", get_process_lines(
+    result = list.hd(default="", process.read.lines(
         "curl -fsL #{playlist_api_url}/next_track?prerecorded=1"))
     if result == "" then
         []
@@ -73,22 +73,12 @@ def log_metadata(m) =
     request_headers = [("Content-Type", "application/x-www-form-urlencoded"),
                        ("X-Requested-With", "johnny-six")]
 
-    http_status =
-        if string.contains(prefix="https", trackman_url) then
-            let ((_,http_status,_),_,_) = https.post(
-                data=params,
-                headers=request_headers,
-                trackman_url)
-            http_status
-        else
-            let ((_,http_status,_),_,_) = http.post(
-                data=params,
-                headers=request_headers,
-                trackman_url)
-            http_status
-        end
+    let http_response = http.post(
+        data=params,
+        headers=request_headers,
+        trackman_url)
 
-    if http_status == 201 then
+    if http_response.status_code == 201 then
         log(label="log_metadata", "Track logged successfully")
     else
         log(label="log_metadata",  "Failed to log track")
@@ -111,7 +101,7 @@ def log_metadata_async(m) =
         log_metadata(m)
         -1.
     end
-    add_timeout(fast=false, 0.1, log_metadata_async_call)
+    thread.run.recurrent(fast=false, delay=0.1, log_metadata_async_call)
 end
 
 # create underwriting queue - if API is disabled, just leave it empty
@@ -133,8 +123,8 @@ end
 
 # convert tracks to stereo, strip silence at beginning and ends of tracks, log
 # metadata on track change, and add liner every 4 tracks
-radio = eat_blank(audio_to_stereo(tracks))
-radio = on_track(log_metadata_async, radio)
+radio = blank.eat(tracks)
+radio.on_track(log_metadata_async)
 radio = rotate(weights=[4, 1], [radio, liner])
 
 # add an additional queue for prerecorded shows that logs everything
@@ -146,12 +136,11 @@ prerecorded = if playlist_api_url != "" then
 else
     request.queue(id="prerecorded")
 end
-prerecorded = audio_to_stereo(prerecorded)
-prerecorded = on_track(log_metadata, prerecorded)
+prerecorded.on_track(log_metadata)
 
 # use external script for remote live stream auth
-def remote_live_auth(user, password) =
-    ret = get_process_lines("python3 #{script_path}/check_auth.py --user=#{user} --password=#{password}")
+def remote_live_auth(args) =
+    ret = get_process_lines("python3 #{script_path}/check_auth.py --user=#{args.user} --password=#{args.password}")
     result = list.hd(default="", ret)
     if result == "true" then
         true
@@ -161,7 +150,7 @@ def remote_live_auth(user, password) =
 end
 
 # add a harbor input for remote live streams
-remote_live = input.harbor.ssl(
+remote_live = input.harbor(
     id="remote_live",
     auth=remote_live_auth,
     replay_metadata=true,

--- a/radio.liq
+++ b/radio.liq
@@ -76,7 +76,6 @@ def log_metadata(m) =
     let http_response = http.post(
         data=params,
         headers=request_headers,
-        normalize_url=true,
         trackman_url)
 
     if http_response.status_code == 201 then

--- a/radio.liq
+++ b/radio.liq
@@ -81,7 +81,7 @@ def log_metadata(m) =
     if http_response.status_code == 201 then
         log(label="log_metadata", "Track logged successfully")
     else
-        log(label="log_metadata",  "Failed to log track #{params} -- #{http_response}")
+        log(label="log_metadata",  "Failed to log track #{http_response}")
     end
 end
 

--- a/radio.liq
+++ b/radio.liq
@@ -81,7 +81,7 @@ def log_metadata(m) =
     if http_response.status_code == 201 then
         log(label="log_metadata", "Track logged successfully")
     else
-        log(label="log_metadata",  "Failed to log track #{http_response}")
+        log(label="log_metadata",  "Failed to log track #{params} -- #{http_response}")
     end
 end
 

--- a/radio.liq
+++ b/radio.liq
@@ -76,6 +76,7 @@ def log_metadata(m) =
     let http_response = http.post(
         data=params,
         headers=request_headers,
+        normalize_url=true,
         trackman_url)
 
     if http_response.status_code == 201 then

--- a/radio.liq
+++ b/radio.liq
@@ -40,7 +40,7 @@ def prerecorded_request() =
 end
 
 def load_traffic(~id="", path) =
-    eat_blank(audio_to_stereo(playlist(id=id, mode="randomize", reload=14400, path)))
+    blank.eat(playlist(id=id, mode="randomize", reload=14400, path))
 end
 
 station_id = load_traffic(id="id", "#{base_path}/playlists/id.m3u")

--- a/wuvt.liq
+++ b/wuvt.liq
@@ -11,7 +11,7 @@ set("scheduler.generic_queues", 6)
 
 %include "radio.liq"
 
-alsa_output = getenv("ALSA_OUTPUT")
+alsa_output = environment.get("ALSA_OUTPUT")
 if alsa_output == "" then
     output.pulseaudio(radio)
 else

--- a/wuvt.liq
+++ b/wuvt.liq
@@ -1,13 +1,13 @@
 # WUVT Automation
 
-set("log.file", false)
-set("log.stdout", true)
+settings.log.file := false
+settings.log.stdout := true
 
-set("server.socket", true)
-set("server.socket.path", "/tmp/liquidsoap.sock")
+settings.server.socket := true
+settings.server.socket.path := "/tmp/liquidsoap.sock"
 
-set("scheduler.fast_queues", 1)
-set("scheduler.generic_queues", 6)
+settings.scheduler.fast_queues := 1
+settings.scheduler.generic_queues := 6
 
 %include "radio.liq"
 


### PR DESCRIPTION
Updated from Liquidsoap 1 to 2. SSL by default is not enabled on the docker images provided by Liquidsoap so the Harbor SSL functionality was removed. The removal requires a reverse proxy with SSL support to be used to securely access johnny-six's Harbor HTTP server.

Resolves #23 